### PR TITLE
Remove profit series from reports charts

### DIFF
--- a/src/features/Reports/ReportsAndInsights.tsx
+++ b/src/features/Reports/ReportsAndInsights.tsx
@@ -74,7 +74,7 @@ const KPICard: React.FC<{
                     background: value > 0 ?
                         `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.02)} 0%, ${alpha(theme.palette.primary.main, 0.08)} 100%)`
                         : `linear-gradient(135deg, ${alpha(theme.palette.error.main, 0.02)} 0%, ${alpha(theme.palette.error.main, 0.08)} 100%)`,
-                    border:  value > 0 ? `1px solid ${alpha(theme.palette.primary.main, 0.12)}` : `1px solid ${alpha(theme.palette.error.main, 0.12)}`,
+                    border: value > 0 ? `1px solid ${alpha(theme.palette.primary.main, 0.12)}` : `1px solid ${alpha(theme.palette.error.main, 0.12)}`,
                 }}
             >
                 <CardContent>
@@ -378,12 +378,12 @@ const ReportsAndInsights: React.FC = () => {
                                                             Purchases
                                                         </Typography>
                                                     </Box>
-                                                    <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                                                    {/* <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
                                                         <Circle sx={{ color: "hsl(195, 85%, 40%)", fontSize: 12 }} />
                                                         <Typography variant="caption" sx={{ fontWeight: 500 }}>
                                                             Profit
                                                         </Typography>
-                                                    </Box>
+                                                    </Box> */}
                                                 </Stack>
 
                                                 <MonthYearSelector
@@ -414,6 +414,7 @@ const ReportsAndInsights: React.FC = () => {
                                                         showMark: true,
                                                         curve: 'catmullRom',
                                                         connectNulls: true,
+                                                        area: true,
                                                         data: dailyData?.data?.find(d => d.id === 'sales')?.data.slice(0, dailyDataLabels.length) || [],
                                                     },
                                                     {
@@ -424,29 +425,37 @@ const ReportsAndInsights: React.FC = () => {
                                                         connectNulls: true,
                                                         data: dailyData?.data?.find(d => d.id === 'purchase')?.data.slice(0, dailyDataLabels.length) || [],
                                                     },
-                                                    {
-                                                        id: 'profit',
-                                                        label: dailyData?.data?.find(d => d.id === 'profit')?.label || 'Daily Profit (₹)',
-                                                        showMark: true,
-                                                        curve: 'catmullRom',
-                                                        connectNulls: true,
-                                                        area: true,
-                                                        data: dailyData?.data?.find(d => d.id === 'profit')?.data.slice(0, dailyDataLabels.length) || [],
-                                                    },
+                                                    // {
+                                                    //     id: 'profit',
+                                                    //     label: dailyData?.data?.find(d => d.id === 'profit')?.label || 'Daily Profit (₹)',
+                                                    //     showMark: true,
+                                                    //     curve: 'catmullRom',
+                                                    //     connectNulls: true,
+                                                    //     area: true,
+                                                    //     data: dailyData?.data?.find(d => d.id === 'profit')?.data.slice(0, dailyDataLabels.length) || [],
+                                                    // },
                                                 ]}
                                                 height={280}
                                                 margin={{ left: 60, right: 20, top: 20, bottom: 40 }}
                                                 grid={{ horizontal: true }}
                                                 sx={{
-                                                    '& .MuiAreaElement-series-profit': {
-                                                        fill: "url('#series')",
+                                                    // '& .MuiAreaElement-series-profit': {
+                                                    //     fill: "url('#series')",
+                                                    // },
+                                                    // '& .MuiAreaElement-series-purchase': {
+                                                    //     fill: "url('#purchase')",
+                                                    // },
+                                                    '& .MuiAreaElement-series-sales': {
+                                                        fill: "url('#sales')",
                                                     },
                                                 }}
                                                 slotProps={{
                                                     legend: { hidden: true },
                                                 }}
                                             >
-                                                <AreaGradient color={"hsl(195, 70%, 65%)"} id="series" />
+                                                {/* <AreaGradient color={"hsl(195, 70%, 65%)"} id="series" /> */}
+                                                {/* <AreaGradient color={"#2e7d32"} id="purchase" /> */}
+                                                <AreaGradient color={"#c62828"} id="sales" />
                                             </LineChart>
                                         )}
                                     </CardContent>
@@ -522,12 +531,12 @@ const ReportsAndInsights: React.FC = () => {
                                                             Purchases
                                                         </Typography>
                                                     </Box>
-                                                    <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                                                    {/* <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
                                                         <Circle sx={{ color: "hsl(195, 85%, 40%)", fontSize: 12 }} />
                                                         <Typography variant="caption" sx={{ fontWeight: 500 }}>
                                                             Profit
                                                         </Typography>
-                                                    </Box>
+                                                    </Box> */}
                                                 </Stack>
 
                                             </Box>
@@ -545,44 +554,53 @@ const ReportsAndInsights: React.FC = () => {
                                             ]}
                                             series={[
                                                 {
-                                                    id: 'series-0',
+                                                    id: 'sales',
                                                     label: monthlyData?.data.find(d => d.id === 'sales')?.label || 'Monthly Sales (₹)',
                                                     showMark: true,
                                                     curve: 'catmullRom',
                                                     connectNulls: true,
+                                                    area: true,
                                                     data: shiftToFinancialYear(monthlyData?.data.find(d => d.id === 'sales')?.data),
                                                 },
                                                 {
-                                                    id: 'series-1',
+                                                    id: 'purchase',
                                                     label: monthlyData?.data.find(d => d.id === 'purchase')?.label || 'Monthly Purchases (₹)',
                                                     showMark: true,
                                                     curve: 'catmullRom',
                                                     connectNulls: true,
                                                     data: shiftToFinancialYear(monthlyData?.data.find(d => d.id === 'purchase')?.data),
                                                 },
-                                                {
-                                                    id: 'profit',
-                                                    label: monthlyData?.data.find(d => d.id === 'profit')?.label || 'Monthly Profit (₹)',
-                                                    showMark: true,
-                                                    curve: 'catmullRom',
-                                                    connectNulls: true,
-                                                    area: true,
-                                                    data: shiftToFinancialYear(monthlyData?.data.find(d => d.id === 'profit')?.data),
-                                                },
+                                                // {
+                                                //     id: 'profit',
+                                                //     label: monthlyData?.data.find(d => d.id === 'profit')?.label || 'Monthly Profit (₹)',
+                                                //     showMark: true,
+                                                //     curve: 'catmullRom',
+                                                //     connectNulls: true,
+                                                //     area: true,
+                                                //     data: shiftToFinancialYear(monthlyData?.data.find(d => d.id === 'profit')?.data),
+                                                // },
                                             ]}
                                             height={280}
                                             margin={{ left: 60, right: 20, top: 20, bottom: 40 }}
                                             grid={{ horizontal: true }}
                                             sx={{
-                                                '& .MuiAreaElement-series-profit': {
-                                                    fill: "url('#series')",
+                                                // '& .MuiAreaElement-series-profit': {
+                                                //     fill: "url('#series')",
+                                                // },
+                                                // '& .MuiAreaElement-series-purchase': {
+                                                //     fill: "url('#purchase')",
+                                                // },
+                                                '& .MuiAreaElement-series-sales': {
+                                                    fill: "url('#sales')",
                                                 },
                                             }}
                                             slotProps={{
                                                 legend: { hidden: true },
                                             }}
                                         >
-                                            <AreaGradient color={"hsl(195, 70%, 65%)"} id="series" />
+                                            {/* <AreaGradient color={"hsl(195, 70%, 65%)"} id="series" /> */}
+                                            {/* <AreaGradient color={"#2e7d32"} id="purchase" /> */}
+                                            <AreaGradient color={"#c62828"} id="sales" />
                                         </LineChart>
                                     </CardContent>
                                 </Card>

--- a/src/pages/Summary.tsx
+++ b/src/pages/Summary.tsx
@@ -427,7 +427,7 @@ const Summary: React.FC = () => {
                             {
                                 title: 'Monthly Revenue',
                                 value: `₹${summaryStats.total_revenue}`,
-                                desc: 'Total revenue generated this month',
+                                desc: 'Total revenue generated in this period',
                                 color: '#e8f4fd',
                                 borderColor: '#1976d2',
                                 icon: <TrendingUpIcon sx={{ fontSize: 40, opacity: 0.3 }} />,
@@ -436,7 +436,7 @@ const Summary: React.FC = () => {
                             {
                                 title: 'Tax Amount',
                                 value: `₹${summaryStats.total_tax}`,
-                                desc: 'Total tax collected this month',
+                                desc: 'Total tax amount for this period',
                                 color: '#fff8e1',
                                 borderColor: '#ff9800',
                                 icon: <AssessmentIcon sx={{ fontSize: 40, opacity: 0.3 }} />,
@@ -456,14 +456,14 @@ const Summary: React.FC = () => {
                                             right: 0,
                                             color: item.borderColor
                                         }}>
-                                            <Tooltip title={`${item.trend} from last month`} arrow>
+                                            {/* <Tooltip title={`${item.trend} from last month`} arrow>
                                                 <Chip
                                                     label={item.trend}
                                                     size="small"
                                                     color="success"
                                                     sx={{ fontSize: '0.7rem', height: 20 }}
                                                 />
-                                            </Tooltip>
+                                            </Tooltip> */}
                                         </Box>
                                         <Box>
                                             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>


### PR DESCRIPTION
Commented out the profit series and related legend elements from both daily and monthly LineChart components in ReportsAndInsights. Updated Summary page descriptions to refer to 'this period' instead of 'this month'.